### PR TITLE
fix json bug, improved error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Attributes: A block of freeform Json for you to set additional descriptive attri
 
 ## Using
 
-Intended use is through the Piazza service, though it can also be used as a standalone service.  Currently accepts both GET and POST calls, with identical parameters.  Actually using the service requires that you call the "execute" endpoint of whatever base the service is called on (example: "http://localhost:8080/execute").  Beyond that, valid and accepted parameters (query parameters for Get, form parameters for POST) are as follows:
+Intended use is through the Piazza service, though it can also be used as a standalone service.  Currently accepts both GET and POST calls, with identical parameters.  Actually using the service requires that you call the "execute" endpoint of whatever base the service is called on (example: "http://localhost:8080/execute", if running locally on port 8080).  Beyond that, valid and accepted parameters (query parameters for Get, form parameters for POST) are as follows:
 
 cmd: The second part of the exec call (following CliCmd).  Additional commands after the first are not supported.  Allows the user some control over the process by influencing input params.
 

--- a/main.go
+++ b/main.go
@@ -45,18 +45,7 @@ type outStruct struct {
 	InFiles		map[string]string
 	OutFiles	map[string]string
 	ProgReturn	string
-	Error		string
-}
-
-type pzCont struct {
-	Type		string
-	Content		string
-	MimeType	string
-}
-
-type pzWrap struct {
-	DataType	pzCont
-	metadata	map[string]string
+	Errors		[]string
 }
 
 func main() {
@@ -145,18 +134,18 @@ func main() {
 
 				runID, err := psuUUID()
 				if err != nil {
-					addErr(&output.Error, err.Error())
+					output.Errors = append(output.Errors, err.Error())
 				}
 
 				err = os.Mkdir("./"+runID, 0777)
 				if err != nil {
-					addErr(&output.Error, err.Error())
+					output.Errors = append(output.Errors, err.Error())
 				}
 				defer os.RemoveAll("./" + runID)
 
 				err = os.Chmod("./"+runID, 0777)
 				if err != nil {
-					addErr(&output.Error, err.Error())
+					output.Errors = append(output.Errors, err.Error())
 				}
 
 				if len(inFileSlice) > 0 {
@@ -171,7 +160,7 @@ func main() {
 					fmt.Printf("Downloading file %s - %d of %d.\n", inFile, i, len(inFileSlice))
 					fname, err := pzsvc.Download(inFile, runID, configObj.PzAddr)
 					if err != nil {
-						addErr(&output.Error, err.Error())
+						output.Errors = append(output.Errors,err.Error())
 						fmt.Printf("Download failed.  %s", err.Error())
 					} else {
 						output.InFiles[inFile] = fname
@@ -180,7 +169,7 @@ func main() {
 				}
 
 				if len(cmdSlice) == 0 {
-					addErr(&output.Error, `No cmd specified in config file.  Please provide "cmd" param.`)
+					output.Errors = append(output.Errors, `No cmd specified in config file.  Please provide "cmd" param.`)
 					break
 				}
 
@@ -205,7 +194,7 @@ func main() {
 
 				err = clc.Run()
 				if err != nil {
-					addErr(&output.Error, err.Error())
+					output.Errors = append(output.Errors, err.Error())
 				}
 				fmt.Printf("Program output: %s\n", b.String())
 				output.ProgReturn = b.String()
@@ -225,7 +214,7 @@ func main() {
 					fmt.Printf("Uploading Txt %s - %d of %d.\n", outTxt, i, len(outTxtSlice))
 					dataID, err := pzsvc.IngestTxt(outTxt, runID, configObj.PzAddr, cmdSlice[0])
 					if err != nil {
-						addErr(&output.Error, err.Error())
+						output.Errors = append(output.Errors, err.Error())
 						fmt.Printf("Upload failed.  %s", err.Error())
 					} else {
 						output.OutFiles[outTxt] = dataID
@@ -236,40 +225,45 @@ func main() {
 					fmt.Printf("Uploading GeoJson %s - %d of %d.\n", outGeoJ, i, len(outGeoJSlice))
 					dataID, err := pzsvc.IngestGeoJson(outGeoJ, runID, configObj.PzAddr, cmdSlice[0])
 					if err != nil {
-						addErr(&output.Error, err.Error())
+						output.Errors = append(output.Errors, err.Error())
 						fmt.Printf("Upload failed.  %s", err.Error())
 					} else {
 						output.OutFiles[outGeoJ] = dataID
 					}
 				}
 
-				outBuf, err := json.Marshal(output)
-				if err != nil {
-					addErr(&output.Error, err.Error())
-				}
-
-				outStr := string(outBuf)
-
 				// this isn't a thing now, but might again become a thing later.
 				if usePz != "" {
+					
+					type pzCont struct {
+						Type		string
+						Content		string
+						MimeType	string
+					}
+
+					type pzWrap struct {
+						DataType	pzCont
+						metadata	map[string]string
+					}
+										
 					var cont pzCont
 					var wrap pzWrap
-
+					outBuf, err := json.Marshal(output)
+					if err != nil {
+						output.Errors = append(output.Errors, err.Error())
+					}
+				
 					cont.Type = "text"
-					cont.Content = outStr
+					cont.Content = string(outBuf)
 					cont.MimeType = "text/plain"
 
 					wrap.DataType = cont
 
-					outBuf, err := json.Marshal(wrap)
-					if err != nil {
-						fmt.Fprintf(w, err.Error())
-					}
-
-					outStr = string(outBuf)
+					printJson(wrap, w)
+				} else {
+					printJson(output, w)
 				}
 
-				fmt.Fprintf(w, outStr)
 
 			}
 		case "/description":
@@ -314,10 +308,13 @@ func psuUUID() (string, error) {
 	return fmt.Sprintf("%X-%X-%X-%X-%X", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
 }
 
-func addErr (thisErr *string, nextErr string) {
-	if *thisErr == "" {
-		*thisErr = nextErr
-	} else {
-		*thisErr = *thisErr + ";  " + nextErr
-	}
+func printJson (output interface{}, w http.ResponseWriter) {
+
+				outBuf, err := json.Marshal(output)
+				if err != nil {
+					fmt.Fprintf(w, `{"Errors":"Json marshalling failure.  Data not reportable."}`)
+				}
+
+				outStr := string(outBuf)
+				fmt.Fprintf(w, outStr)
 }

--- a/main.go
+++ b/main.go
@@ -196,8 +196,8 @@ func main() {
 				if err != nil {
 					output.Errors = append(output.Errors, err.Error())
 				}
-				fmt.Printf("Program output: %s\n", b.String())
-				output.ProgReturn = b.String()
+				fmt.Printf("Program output: %+q\n", b.String())
+				output.ProgReturn = fmt.Sprintf("%+q", b.String())
 
 				for i, outTiff := range outTiffSlice {
 					fmt.Printf("Uploading Tiff %s - %d of %d.\n", outTiff, i, len(outTiffSlice))
@@ -259,9 +259,9 @@ func main() {
 
 					wrap.DataType = cont
 
-					printJson(wrap, w)
+					printJson(w, wrap)
 				} else {
-					printJson(output, w)
+					printJson(w, output)
 				}
 
 
@@ -276,9 +276,7 @@ func main() {
 			if configObj.Attributes == nil {
 				fmt.Fprintf(w, "{ }")
 			} else {
-				// convert attributes back into Json
-				// this might require specifying the interface a bit better.
-				//					fmt.Fprintf(w, configObj.Attributes)
+				printJson(w, configObj.Attributes)
 			}
 		case "/help":
 			fmt.Fprintf(w, "We're sorry, help is not yet implemented.\n")
@@ -298,7 +296,6 @@ func splitOrNil(inString, knife string) []string {
 }
 
 func psuUUID() (string, error) {
-
 	b := make([]byte, 16)
 	_, err := rand.Read(b)
 	if err != nil {
@@ -308,13 +305,12 @@ func psuUUID() (string, error) {
 	return fmt.Sprintf("%X-%X-%X-%X-%X", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
 }
 
-func printJson (output interface{}, w http.ResponseWriter) {
+func printJson (w http.ResponseWriter, output interface{}) {
+	outBuf, err := json.Marshal(output)
+	if err != nil {
+		fmt.Fprintf(w, `{"Errors":"Json marshalling failure.  Data not reportable."}`)
+	}
 
-				outBuf, err := json.Marshal(output)
-				if err != nil {
-					fmt.Fprintf(w, `{"Errors":"Json marshalling failure.  Data not reportable."}`)
-				}
-
-				outStr := string(outBuf)
-				fmt.Fprintf(w, outStr)
+	outStr := string(outBuf)
+	fmt.Fprintf(w, outStr)
 }

--- a/pzsvc/register.go
+++ b/pzsvc/register.go
@@ -121,6 +121,7 @@ func ManageRegistration(svcName, svcDesc, svcUrl, pzAddr string, imgReq map[stri
 		}
 		imgReq = newImgReq
 	}
+//TODO: imgReq may not be generic enough.  Look into/reconsider.
 	
 	fmt.Println("Finding")
 	svcId, err := FindMySvc(svcName, pzAddr)


### PR DESCRIPTION
Modified pzsvc-exec to (hopefully) filter out the sorts of non-printable characters that coudl cause thigns to choke on the other end.  Also tweaked the error messages to pass back a list of messages, rather than a semicolon-separated string.
