### PR TITLE
User Facing Error Messages

### DIFF
--- a/worker/ingest/ingest.go
+++ b/worker/ingest/ingest.go
@@ -61,7 +61,7 @@ func assembleIngestorCalls(cfg config.WorkerConfig, algFullCommand string, algVe
 		if _, fStatErr := os.Stat(filePath); fStatErr != nil {
 			errMsg := fmt.Sprintf("error statting file `%s`: %v", filePath, fStatErr)
 			workerlog.SimpleErr(cfg, errMsg, fStatErr)
-			outputErrors = append(outputErrors, errors.New(errMsg))
+			outputErrors = append(outputErrors, errors.New("error validating outputs"))
 			continue
 		}
 

--- a/worker/ingest/ingest_async.go
+++ b/worker/ingest/ingest_async.go
@@ -38,7 +38,7 @@ func (ingestor defaultAsyncIngestor) ingestFileAsync(s pzsvc.Session, filePath, 
 		case <-pzSvcIngestorInstance.Timeout():
 			outChan <- singleIngestOutput{
 				FilePath: filePath,
-				Error:    errors.New("File ingest timed out"),
+				Error:    errors.New("Unexpected error storing job output"),
 			}
 		}
 		close(outChan)

--- a/worker/input/download_async.go
+++ b/worker/input/download_async.go
@@ -61,7 +61,7 @@ func (dl defaultAsyncDownloader) DownloadInputAsync(source config.InputSource) c
 		for i := 0; i <= dl.Retries; i++ {
 			resp, err = httpClient.Get(source.URL)
 			if err == nil && resp.StatusCode != http.StatusOK {
-				err = fmt.Errorf("Unexpected HTTP status: %v", resp.StatusCode)
+				err = fmt.Errorf("unexpected status downloading input (%v)", resp.StatusCode)
 			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to download URL %s on the %d attempt: %v. Timing out after %d retries.\n", source.URL, i+1, err, dl.Retries)

--- a/worker/input/fetch_input.go
+++ b/worker/input/fetch_input.go
@@ -35,7 +35,7 @@ func FetchInputs(cfg config.WorkerConfig, inputs []config.InputSource) error {
 	for i, errChan := range inputResults {
 		err := <-errChan
 		if err != nil {
-			errors = append(errors, fmt.Errorf("error downloading input: %s; %v ", inputs[i].FileName, err))
+			errors = append(errors, fmt.Errorf("error downloading input"))
 		} else {
 			workerlog.Info(cfg, fmt.Sprintf("downloaded input: %s", inputs[i].FileName))
 		}

--- a/worker/workerexec/command_runner.go
+++ b/worker/workerexec/command_runner.go
@@ -47,11 +47,11 @@ func (dcr commandRunner) Run(cfg config.WorkerConfig, command string) (out comma
 
 	if out.Error != nil {
 		if exitErr, ok := out.Error.(*exec.ExitError); ok {
-			workerlog.SimpleErr(cfg, "failed executing command; stderr below", exitErr)
+			workerlog.SimpleErr(cfg, "failed executing algorithm command; stderr below", exitErr)
 			workerlog.Alert(cfg, string(exitErr.Stderr))
 			out.Stderr = exitErr.Stderr
 		} else {
-			workerlog.SimpleErr(cfg, "failed executing command; stderr not available", err)
+			workerlog.SimpleErr(cfg, "failed executing algorithm command; stderr not available", err)
 		}
 	} else {
 		workerlog.Info(cfg, "runCommandOutput success")


### PR DESCRIPTION
The Beachfront user interface needs some way to get proper user-facing error messages that can be displayed in the UI for users. Not too much detail. Just high-level information on what failed in the algorithm.

The application logs are where the detailed information should reside. 

This PR attempts to clean up some of the user-facing error messages that will end up getting displayed in the UI. 