### PR TITLE
Increase Ingest Timeout

### DIFF
--- a/worker/ingest/ingest_async.go
+++ b/worker/ingest/ingest_async.go
@@ -62,7 +62,7 @@ func (ingestor defaultPzSvcIngestor) IngestFile(s pzsvc.Session, fName, fType, s
 }
 
 func (ingestor defaultPzSvcIngestor) Timeout() <-chan time.Time {
-	return time.After(1 * time.Minute)
+	return time.After(3 * time.Minute)
 }
 
 var pzSvcIngestorInstance pzSvcIngestor = &defaultPzSvcIngestor{}


### PR DESCRIPTION
When ingesting large files (inland datasets with coast mask disabled) the ingest is taking longer than 1 minute. Especially when we talk about degraded network connections in different environments, this timeout really needs to be higher. 